### PR TITLE
Feature/method payloads

### DIFF
--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -567,6 +567,9 @@ fileprivate class HubConnectionConnectionDelegate: ConnectionDelegate {
  */
 public class ArgumentExtractor {
     let clientInvocationMessage: ClientInvocationMessage
+    
+    /// Raw collection of argument `Data` provided with the client message.
+    public var argumentPayloads: [Data] { clientInvocationMessage.argumentPayloads }
 
     /**
      Initializes an `ArgumentExtractor` with the received `ClientInvocationMessage`.

--- a/Sources/SignalRClient/HubConnectionExtensions.swift
+++ b/Sources/SignalRClient/HubConnectionExtensions.swift
@@ -561,6 +561,22 @@ public extension HubConnection {
 
         self.on(method: method, callback: cb)
     }
+    
+    /// Registers a callback for a client-side hub method that relays arguments as a collection of bytes (`[Data]`)
+    ///
+    /// In some scenarios, a `Decodable` data-type may not be known or concrete at the point of registering a method callback.
+    /// This method allows for accessing the underlying bytes (_JSON collections/fragments when using the `JSONHubProtocol`_) that
+    /// represent the arguments sent by the server, This allows an implementer the ability to decode when convenient or attempt alternative
+    /// decoding.
+    ///
+    /// - parameters:
+    ///   - method: The name of the client-side method for which to register the callback.
+    ///   - callback: Function that will be called when the `method` is invoked from the server.
+    func on(method: String, callback: @escaping ([Data]) -> Void) {
+        on(method: method) { (argumentExtractor: ArgumentExtractor) in
+            callback(argumentExtractor.argumentPayloads)
+        }
+    }
 
     /**
      Allows registering callbacks for client side hub methods with 1 parameter.

--- a/Sources/SignalRClient/HubProtocol.swift
+++ b/Sources/SignalRClient/HubProtocol.swift
@@ -81,8 +81,9 @@ public class ClientInvocationMessage: HubMessage, Decodable {
     public let type = MessageType.Invocation
     public let target: String
     private var arguments: UnkeyedDecodingContainer?
+    public internal(set) var argumentPayloads: [Data] = []
 
-    public required init (from decoder: Decoder) throws {
+    public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         target = try container.decode(String.self, forKey: .target)
         if container.contains(.arguments) {
@@ -122,13 +123,13 @@ public class StreamItemMessage: HubMessage, Codable {
     let container: KeyedDecodingContainer<StreamItemMessage.CodingKeys>?
     let item: Encodable?
 
-    public required init (from decoder: Decoder) throws {
+    public required init(from decoder: Decoder) throws {
         container = try decoder.container(keyedBy: CodingKeys.self)
         invocationId = try container!.decode(String.self, forKey: .invocationId)
         item = nil
     }
 
-    public init (invocationId: String, item: Encodable) {
+    public init(invocationId: String, item: Encodable) {
         self.invocationId = invocationId
         self.item = item
         container = nil
@@ -170,14 +171,14 @@ public class CompletionMessage: HubMessage, Codable {
     public let hasResult: Bool
     let container: KeyedDecodingContainer<CompletionMessage.CodingKeys>?
 
-    public required init (from decoder: Decoder) throws {
+    public required init(from decoder: Decoder) throws {
         container = try decoder.container(keyedBy: CodingKeys.self)
         invocationId = try container!.decode(String.self, forKey: .invocationId)
         error = try container!.decodeIfPresent(String.self, forKey: .error)
         hasResult = container!.contains(.result)
     }
 
-    public init (invocationId: String, error: String?) {
+    public init(invocationId: String, error: String?) {
         self.invocationId = invocationId
         self.error = error
         hasResult = false

--- a/Tests/SignalRClientTests/HubConnectionTests.swift
+++ b/Tests/SignalRClientTests/HubConnectionTests.swift
@@ -687,7 +687,7 @@ class HubConnectionTests: XCTestCase {
             .withHubConnectionDelegate(delegate: hubConnectionDelegate)
             .build()
 
-        hubConnection.on(method: "GetNumber", callback: { argumentExtractor in
+        hubConnection.on(method: "GetNumber", callback: { (argumentExtractor: ArgumentExtractor) in
             XCTFail("Should not be invoked")
         })
 


### PR DESCRIPTION
TLDR: Provides access to arguments as a collection of `Data` objects.

---

This change adds a `HubConnection.on(method:callback:)` which returns the arguments provided by the server as a collection of `Data`. It does this by adding a `argumentsPayloads: [Data]` parameter to the `ArgumentsExtractor` and assigns that when receiving a `ClientInvocationMessage`.

---

I was recently working on a generic solution using the `Combine` framework to create a publisher stream to which any interested party could subscribe. The difficulty came in having to store a collection of typed subject while still being generic. For instance:

```swift
var methodSubjects = [String: PassthroughSubject<[Data], Never>]()

func publisher<T: Decodable>(method: String, using decoder: JSONDecoder = .init()) -> AnyPublisher<T, Error> {
    let subject = methodSubjects[method] // or create/terminate & update if needed
    return subject
        .compactMap { $0.first }
        .decode(type: T.self, decoder: decoder)
        .eraseToAnyPublisher()
}
```

This would put the control of the type information in control of the caller as opposed to needing to track that for the individual subjects.